### PR TITLE
Fix #1 Error of Mixed Content via HTTPS in fetch

### DIFF
--- a/argenteamIMDBscore.js
+++ b/argenteamIMDBscore.js
@@ -11,7 +11,7 @@ for(let pos in moviesInfo){
     } catch(err) {
       continue
     }
-    url = "http://www.omdbapi.com/?apikey=6d863fde&t=" + filmName + "&y=" + year;
+    url = "https://www.omdbapi.com/?apikey=6d863fde&t=" + filmName + "&y=" + year;
     fetch(url)
         .then(function(response) {
             return response.json();


### PR DESCRIPTION
Fix #1 via simply using HTTPS. I don't know if it could break the page in other browsers which might still use `http://argenteam.net` instead of `HTTPS://argenteam.net`. But I guess it won't. And Chrome automatically redirects me from HTTP to HTTPS anyway.